### PR TITLE
Fix broken link on docsite homepage

### DIFF
--- a/apps/docsite/src/pages/index.tsx
+++ b/apps/docsite/src/pages/index.tsx
@@ -6,6 +6,7 @@ import HomepageFeatures from '@site/src/components/HomepageFeatures';
 import Heading from '@theme/Heading';
 
 import styles from './index.module.css';
+import sidebars from '@site/sidebars';
 
 function HomepageHeader() {
   const {siteConfig} = useDocusaurusContext();
@@ -19,7 +20,7 @@ function HomepageHeader() {
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/Fluent-React-Charting">
+            to={`/docs/${sidebars.tutorialSidebar[0]}`}>
             Getting Started 🚈
           </Link>
         </div>


### PR DESCRIPTION
This PR fixes the Getting Started link on the docsite homepage and links it to the first doc on the main sidebar.
https://jam.dev/c/32ee2917-21b0-4f02-b0e5-87029119abc9
Fixes #35