### PR TITLE
Adding example for vertical stacked bar chart using v9 tokens

### DIFF
--- a/tools/v9-migration/src/components/BarChartHoverCard/BarChartHoverCard.styles.ts
+++ b/tools/v9-migration/src/components/BarChartHoverCard/BarChartHoverCard.styles.ts
@@ -1,0 +1,47 @@
+// import {Neutral51} from '@/components/theme/colors';
+import {makeStyles, shorthands, tokens} from '@fluentui/react-components';
+
+export const useBarChartHoverCardClasses = makeStyles({
+    root: {
+        display: 'flex',
+        flexDirection: 'column',
+        backgroundColor: '#202427', //'var(--colorPaletteRedBackground1)',//tokens.colorNeutralBackgroundInverted1,// '#242A2E', //tokens.colorNeutralBackgroundInverted, //, //Neutral51[16],
+        width: 'auto',
+        height: 'auto',
+        color: '#D2D7D9', //tokens.colorNeutralBackground3Pressed,
+        ...shorthands.padding('12px', '16px', '16px', '16px'), // Adding tokens makes it not respect the values provided
+        ...shorthands.gap('12px'), // Adding tokens makes it not respect the values provided
+    },
+    datetime: {},
+    usageStatus: {
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        ...shorthands.gap('6px'), // Adding tokens makes it not respect the values provided
+    },
+    usageStatusIcon: {
+        height: '14px',
+        width: '14px',
+    },
+    usageStatusText: {
+        fontWeight: tokens.fontWeightSemibold, //tokens.fontWeightSemibold - 600,
+    },
+    usageBox: {
+        display: 'flex',
+        flexDirection: 'row',
+    },
+    usageBar: {
+        height: '40px',
+        width: '4px', // Adding tokens makes it not respect the values provided
+        backgroundColor: tokens.colorBrandBackground2, //tokens.colorBrandBackground2 - '#58D3DB', // Not sure why tokens.colorBrandBackground2 isn't working even after using !important
+    },
+    usageValueBox: {
+        display: 'flex',
+        flexDirection: 'column',
+        ...shorthands.padding('0px', '0px', '0px', '8px'),
+    },
+    usageValue: {
+        color: tokens.colorNeutralStrokeOnBrand2,
+        fontWeight: tokens.fontWeightBold, //tokens.fontWeightBold, //tokens.fontWeightBold - 700, // Adding tokens makes it not respect the values provided
+    },
+});

--- a/tools/v9-migration/src/components/BarChartHoverCard/BarChartHoverCard.tsx
+++ b/tools/v9-migration/src/components/BarChartHoverCard/BarChartHoverCard.tsx
@@ -1,0 +1,33 @@
+import {useBarChartHoverCardClasses} from './BarChartHoverCard.styles';
+import {BarChartHoverCardProps} from './BarChartHoverCard.types';
+import {getDayName, getHourlyTimeframe} from './BarChartHoverCard.utils';
+
+export default function BarChartHoverCard(props: BarChartHoverCardProps) {
+    const classes = useBarChartHoverCardClasses();
+    const {calloutData} = props;
+    const usageValue = calloutData.chartData.reduce((sum, item) => sum + item.data, 0);
+    const usageStatus =
+        calloutData.xAxisCalloutData;
+
+    return (
+        <div className={classes.root}>
+            <div className={classes.datetime}>
+                <div>{getDayName(calloutData.xAxisPoint)}</div>
+                <div>{getHourlyTimeframe(calloutData.xAxisPoint)}</div>
+            </div>
+            {usageStatus && (
+                <div className={classes.usageStatus}>
+                    <div className={classes.usageStatusIcon}>Icon</div>
+                    <div className={classes.usageStatusText}>Status</div>
+                </div>
+            )}
+            <div className={classes.usageBox}>
+                <div className={classes.usageBar} />
+                <div className={classes.usageValueBox}>
+                    <div>Usage</div>
+                    <div className={classes.usageValue}>{usageValue.toFixed(1)}</div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/tools/v9-migration/src/components/BarChartHoverCard/BarChartHoverCard.types.ts
+++ b/tools/v9-migration/src/components/BarChartHoverCard/BarChartHoverCard.types.ts
@@ -1,0 +1,5 @@
+import {IVerticalStackedChartProps} from '@fluentui/react-charting';
+
+export type BarChartHoverCardProps = {
+    calloutData: IVerticalStackedChartProps;
+};

--- a/tools/v9-migration/src/components/BarChartHoverCard/BarChartHoverCard.utils.ts
+++ b/tools/v9-migration/src/components/BarChartHoverCard/BarChartHoverCard.utils.ts
@@ -1,0 +1,21 @@
+export function getDayName(dateTime: Date | string | number) {
+    const date = new Date(dateTime);
+    return date.toLocaleString('default', {weekday: 'long'});
+}
+
+export function getHourlyTimeframe(dateTime: Date | string | number): string {
+    const date = new Date(dateTime);
+    let hour = date.getUTCHours();
+    const period = hour < 12 ? 'AM' : 'PM';
+
+    if (hour === 0) {
+        hour = 12;
+    } else if (hour > 12) {
+        hour -= 12;
+    }
+
+    const nextHour = (hour % 12) + 1;
+    const nextPeriod = hour < 11 ? period : period === 'AM' ? 'PM' : 'AM';
+
+    return `${hour}:00 ${period} - ${nextHour}:00 ${nextPeriod}`;
+}

--- a/tools/v9-migration/src/components/ChartWrapper.tsx
+++ b/tools/v9-migration/src/components/ChartWrapper.tsx
@@ -18,6 +18,7 @@ import { SparklineChartBasicExample } from './SparklineChart.Basic.Example';
 import { TreeChartThreeLayerExample } from './TreeChart.ThreeLayer.Example';
 import { GaugeChartBasicExample } from './GaugeChart.Basic.Example';
 import * as d3Color from 'd3-color';
+import { VerticalStackedBarChartToBeFixedExample } from './VerticalStackedBarChart.V9ToBeFixed.Example';
 
 
 export function ChartWrapper() {
@@ -56,6 +57,9 @@ export function ChartWrapper() {
       <SparklineChartBasicExample/>
       <Divider appearance='brand'>Gauge Chart<br/></Divider><br/>
       <GaugeChartBasicExample/>
+      <Divider appearance='brand'>Vertical StackedBar Chart (to be fixed)<br/></Divider><br/>
+      <VerticalStackedBarChartToBeFixedExample/>
+      <Divider appearance='brand'/><br/>
     </div>
     </ThemeProvider>
     );

--- a/tools/v9-migration/src/components/VerticalStackedBarChart.V9ToBeFixed.Example.tsx
+++ b/tools/v9-migration/src/components/VerticalStackedBarChart.V9ToBeFixed.Example.tsx
@@ -1,0 +1,320 @@
+import * as React from 'react';
+import {
+  IVSChartDataPoint,
+  IVerticalStackedChartProps,
+  VerticalStackedBarChart,
+  ILineChartLineOptions,
+} from '@fluentui/react-charting';
+import { DefaultPalette } from '@fluentui/react/lib/Styling';
+import { Checkbox } from '@fluentui/react/lib/Checkbox';
+import { Toggle } from '@fluentui/react/lib/Toggle';
+import BarChartHoverCard from './BarChartHoverCard/BarChartHoverCard';
+
+interface IVerticalStackedBarState {
+  width: number;
+  height: number;
+  barGapMax: number;
+  showLine: boolean;
+  hideLabels: boolean;
+  showAxisTitles: boolean;
+  margins: {};
+}
+
+export class VerticalStackedBarChartToBeFixedExample extends React.Component<{}, IVerticalStackedBarState> {
+  constructor(props: IVerticalStackedChartProps) {
+    super(props);
+    this.state = {
+      width: 650,
+      height: 350,
+      showLine: true,
+      barGapMax: 2,
+      hideLabels: false,
+      showAxisTitles: true,
+      margins: {
+        top: 20,
+        bottom: 55,
+        right: 40,
+        left: 60,
+      },
+    };
+  }
+
+  public render(): JSX.Element {
+    return <div key={'id_VBC'}>{this._basicExample()}</div>;
+  }
+
+  private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ width: parseInt(e.target.value, 10) });
+  };
+  private _onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ height: parseInt(e.target.value, 10) });
+  };
+
+  private _onShowLineChange = (ev: React.FormEvent<HTMLElement>, checked: boolean): void => {
+    this.setState({ showLine: checked });
+  };
+  private _onHideLabelsCheckChange = (ev: React.MouseEvent<HTMLElement>, checked: boolean) => {
+    this.setState({ hideLabels: checked });
+  };
+  private _onToggleAxisTitlesCheckChange = (ev: React.MouseEvent<HTMLElement>, checked: boolean) => {
+    this.setState({
+      showAxisTitles: checked,
+    });
+    if (checked) {
+      this.setState({
+        margins: {
+          top: 20,
+          bottom: 55,
+          right: 40,
+          left: 60,
+        },
+      });
+    } else {
+      this.setState({
+        margins: {
+          top: 20,
+          bottom: 35,
+          right: 20,
+          left: 40,
+        },
+      });
+    }
+  };
+
+  private _basicExample(): JSX.Element {
+    const { showLine } = this.state;
+    const firstChartPoints: IVSChartDataPoint[] = [
+      {
+        legend: 'Metadata1',
+        data: 40,
+        color: DefaultPalette.blue,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '61%',
+      },
+      {
+        legend: 'Metadata2',
+        data: 5,
+        color: DefaultPalette.blueMid,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '8%',
+      },
+      {
+        legend: 'Metadata3',
+        data: 20,
+        color: DefaultPalette.blueLight,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '31%',
+      },
+    ];
+
+    const secondChartPoints: IVSChartDataPoint[] = [
+      {
+        legend: 'Metadata1',
+        data: 30,
+        color: DefaultPalette.blue,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '33%',
+      },
+      {
+        legend: 'Metadata2',
+        data: 20,
+        color: DefaultPalette.blueMid,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '22%',
+      },
+      {
+        legend: 'Metadata3',
+        data: 40,
+        color: DefaultPalette.blueLight,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '45%',
+      },
+    ];
+
+    const thirdChartPoints: IVSChartDataPoint[] = [
+      {
+        legend: 'Metadata1',
+        data: 44,
+        color: DefaultPalette.blue,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '43%',
+      },
+      {
+        legend: 'Metadata2',
+        data: 28,
+        color: DefaultPalette.blueMid,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '27%',
+      },
+      {
+        legend: 'Metadata3',
+        data: 30,
+        color: DefaultPalette.blueLight,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '30%',
+      },
+    ];
+
+    const fourthChartPoints: IVSChartDataPoint[] = [
+      {
+        legend: 'Metadata1',
+        data: 88,
+        color: DefaultPalette.blue,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '63%',
+      },
+      {
+        legend: 'Metadata2',
+        data: 22,
+        color: DefaultPalette.blueMid,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '16%',
+      },
+      {
+        legend: 'Metadata3',
+        data: 30,
+        color: DefaultPalette.blueLight,
+        xAxisCalloutData: '2020/04/30',
+        yAxisCalloutData: '21%',
+      },
+    ];
+
+    const data: IVerticalStackedChartProps[] = [
+      {
+        chartData: firstChartPoints,
+        xAxisPoint: 0,
+
+        ...(showLine && {
+          lineData: [
+            { y: 42, legend: 'Supported Builds', color: DefaultPalette.magentaLight },
+            { y: 10, legend: 'Recommended Builds', color: DefaultPalette.redDark },
+          ],
+        }),
+      },
+      {
+        chartData: secondChartPoints,
+        xAxisPoint: 20,
+        ...(showLine && {
+          lineData: [{ y: 33, legend: 'Supported Builds', color: DefaultPalette.magentaLight }],
+        }),
+      },
+      {
+        chartData: thirdChartPoints,
+        xAxisPoint: 40,
+        ...(showLine && {
+          lineData: [
+            { y: 60, legend: 'Supported Builds', color: DefaultPalette.magentaLight },
+            { y: 20, legend: 'Recommended Builds', color: DefaultPalette.redDark },
+          ],
+        }),
+      },
+      {
+        chartData: firstChartPoints,
+        xAxisPoint: 60,
+        ...(showLine && {
+          lineData: [
+            { y: 41, legend: 'Supported Builds', color: DefaultPalette.magentaLight },
+            { y: 10, legend: 'Recommended Builds', color: DefaultPalette.redDark },
+          ],
+        }),
+      },
+      {
+        chartData: fourthChartPoints,
+        xAxisPoint: 80,
+        ...(showLine && {
+          lineData: [
+            { y: 100, legend: 'Supported Builds', color: DefaultPalette.magentaLight },
+            { y: 70, legend: 'Recommended Builds', color: DefaultPalette.redDark },
+          ],
+        }),
+      },
+      {
+        chartData: firstChartPoints,
+        xAxisPoint: 100,
+      },
+    ];
+
+    const lineOptions: ILineChartLineOptions = { lineBorderWidth: '2' };
+
+    const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
+
+    return (
+      <>
+        <label htmlFor="changeWidth_Basic">Change Width:</label>
+        <input
+          type="range"
+          value={this.state.width}
+          min={200}
+          max={1000}
+          id="changeWidth_Basic"
+          onChange={this._onWidthChange}
+          aria-valuetext={`ChangeWidthSlider${this.state.width}`}
+        />
+        <label htmlFor="changeHeight_Basic">Change Height:</label>
+        <input
+          type="range"
+          value={this.state.height}
+          min={200}
+          max={1000}
+          id="changeHeight_Basic"
+          onChange={this._onHeightChange}
+          aria-valuetext={`ChangeHeightslider${this.state.height}`}
+        />
+        <label htmlFor="changeBarGapMax_Basic">BarGapMax:</label>
+        <input
+          type="range"
+          value={this.state.barGapMax}
+          min={0}
+          max={10}
+          id="changeBarGapMax_Basic"
+          onChange={e => this.setState({ barGapMax: +e.target.value })}
+          aria-valuetext={`ChangebarGapMaxSlider${this.state.barGapMax}`}
+        />
+        <BarChartHoverCard calloutData={data[0]} />
+        {this.state.showAxisTitles && (        
+          <div style={rootStyle}>
+            <VerticalStackedBarChart
+              culture={window.navigator.language}
+              chartTitle="Vertical stacked bar chart basic example"
+              barGapMax={this.state.barGapMax}
+              data={data}
+              height={this.state.height}
+              width={this.state.width}
+              margins={this.state.margins}
+              lineOptions={lineOptions}
+              legendProps={{
+                allowFocusOnLegends: true,
+              }}
+              hideLabels={this.state.hideLabels}
+              enableReflow={true}
+              yAxisTitle={this.state.showAxisTitles ? 'Variation of number of sales' : undefined}
+              xAxisTitle={this.state.showAxisTitles ? 'Number of days' : undefined}
+              onRenderCalloutPerStack={(props?: IVerticalStackedChartProps) => {
+                return props ? <BarChartHoverCard calloutData={data[0]} /> : null;
+            }}
+            />
+          </div>
+        )}
+        {!this.state.showAxisTitles && (
+          <div style={rootStyle}>
+            <VerticalStackedBarChart
+              culture={window.navigator.language}
+              chartTitle="Vertical stacked bar chart basic example"
+              barGapMax={this.state.barGapMax}
+              data={data}
+              height={this.state.height}
+              width={this.state.width}
+              margins={this.state.margins}
+              lineOptions={lineOptions}
+              legendProps={{
+                allowFocusOnLegends: true,
+              }}
+              hideLabels={this.state.hideLabels}
+              enableReflow={true}            
+            />
+          </div>
+        )}
+      </>
+    );
+  }
+}


### PR DESCRIPTION
Adding example for vertical stacked bar chart using v9 tokens

Scenario: This bug was noticed in a project that uses Fluent v9. However since react-charting leverages v8, some issues related to token values not getting respected were happening when trying to render a CustomComponent in the callout hover card on VerticalStackedBarChart.

![image](https://github.com/microsoft/fluentui-charting-contrib/assets/120183316/88cd2e81-3fc2-4a0a-884d-2284dacd6086)

Added example (to be fixed):
<img width="1204" alt="image" src="https://github.com/microsoft/fluentui-charting-contrib/assets/120183316/8e7bcbb9-568a-45db-ae49-978a5a42c00d">
