### PR TITLE
Add MD doc for Test Coverage status

### DIFF
--- a/apps/docsite/sidebars.ts
+++ b/apps/docsite/sidebars.ts
@@ -40,6 +40,7 @@ const sidebars: SidebarsConfig = {
     'implementing-2-to-1-spacing',
     'creating-date-objects-for-chart-data',
     'Testing Strategy',
+    'TestCoverage',
     {
       type:'category',
       label:'Test Plans',

--- a/apps/docsite/src/components/GetCoverageJSON.tsx
+++ b/apps/docsite/src/components/GetCoverageJSON.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from "react";
+
+interface GetCoverageJSONProps{
+    OS:string
+}
+const GetCoverageJSON: React.FC<GetCoverageJSONProps> = ({OS}) => {
+  const [coverage, setCoverage] = useState<number | undefined>();
+  const [errorState, setErrorState] = useState<Error | undefined>();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data = await fetch(
+          "https://proud-island-067885010.4.azurestaticapps.net/windowsCoverage.json"
+        ).then((res) => res.json());
+        if (!data) {
+          throw new Error("Invalid response");
+        }
+        setCoverage(data.statementCoverage);
+      } catch (error) {
+        setErrorState(error);
+      }
+    };
+    fetchData();
+  }, []);
+
+  if (errorState) {
+    return (
+      <img
+        src={`https://img.shields.io/badge/Error-fetching-red`}
+        alt="Test Coverage Badge"
+      />
+    );
+  }
+  console.log
+  return (
+    <div>
+      {coverage && (
+        <img
+          src={`https://img.shields.io/badge/${OS}-${coverage}-darkgreen`}
+          alt="Test Coverage Badge"
+        />
+      )}
+    </div>
+  );
+};
+
+export default GetCoverageJSON;

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -1,0 +1,12 @@
+# Test Coverage Report
+Latest test coverage reports across OS.
+It shows the percentage of code covered by various types of tests, including unit tests, component tests, and accessibility tests across chart types.
+Go through it to analyze if your code is validated through test automations.
+
+import GetCoverageJSON from "../apps/docsite/src/components/GetCoverageJSON.tsx"
+
+| OS | Link | Status |
+|----|------|--------|
+| Code coverage for Windows | https://proud-island-067885010.4.azurestaticapps.net/windows-latest/index.html | <GetCoverageJSON OS="Windows"/> |
+| Code coverage for Ubuntu | https://proud-island-067885010.4.azurestaticapps.net/ubuntu-latest/index.html | <GetCoverageJSON OS="Ubuntu"/>  |
+| Code coverage for MacOS | https://proud-island-067885010.4.azurestaticapps.net/macos-latest/index.html | <GetCoverageJSON OS="MacOS"/> |


### PR DESCRIPTION
This PR adds a doc entry in the docsite to show the current status of the test coverage
![image](https://github.com/microsoft/fluentui-charting-contrib/assets/35366351/e242ab95-5fd2-4651-bb6e-7f9c68447599)
Fixes #27 