### PR TITLE
Fix CORS issue in fetch calls in Test Coverage doc

### DIFF
--- a/apps/docsite/src/components/GetCoverageJSON.tsx
+++ b/apps/docsite/src/components/GetCoverageJSON.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from "react";
 
-interface GetCoverageJSONProps{
-    OS:string
+interface GetCoverageJSONProps {
+  OS: string;
 }
-const GetCoverageJSON: React.FC<GetCoverageJSONProps> = ({OS}) => {
+const GetCoverageJSON: React.FC<GetCoverageJSONProps> = ({ OS }) => {
   const [coverage, setCoverage] = useState<number | undefined>();
   const [errorState, setErrorState] = useState<Error | undefined>();
 
@@ -11,7 +11,8 @@ const GetCoverageJSON: React.FC<GetCoverageJSONProps> = ({OS}) => {
     const fetchData = async () => {
       try {
         const data = await fetch(
-          "https://proud-island-067885010.4.azurestaticapps.net/windowsCoverage.json"
+          `https://raw.githubusercontent.com/microsoft/fluentui-charting-contrib/test-coverage-artifacts/${OS.toLowerCase()}Coverage.json`,
+          { mode: "cors" }
         ).then((res) => res.json());
         if (!data) {
           throw new Error("Invalid response");
@@ -32,7 +33,6 @@ const GetCoverageJSON: React.FC<GetCoverageJSONProps> = ({OS}) => {
       />
     );
   }
-  console.log
   return (
     <div>
       {coverage && (


### PR DESCRIPTION
This PR fixes the CORS issue causing fetch failures in thee Test Coverage report doc in the docusaurus docsite
Before:
![image](https://github.com/microsoft/fluentui-charting-contrib/assets/35366351/b8036d28-ad33-42a5-a78a-b1e2745cce89)
After:
![image](https://github.com/microsoft/fluentui-charting-contrib/assets/35366351/700a0794-e27d-4df7-99a8-4824d76429ad)
