### PR TITLE
Fix Coverage report strings

### DIFF
--- a/.github/workflows/bundlesize.yml
+++ b/.github/workflows/bundlesize.yml
@@ -13,6 +13,8 @@ on:
         description: "Branch to run monosize on"
         required: true
         default: "master"
+permissions:
+  contents: write
 jobs:
   run-monosize:
     runs-on: ubuntu-latest

--- a/apps/docsite/src/components/GetCoverageJSON.tsx
+++ b/apps/docsite/src/components/GetCoverageJSON.tsx
@@ -37,7 +37,7 @@ const GetCoverageJSON: React.FC<GetCoverageJSONProps> = ({ OS }) => {
     <div>
       {coverage && (
         <img
-          src={`https://img.shields.io/badge/${OS}-${coverage}-darkgreen`}
+          src={`https://img.shields.io/badge/Coverage-${coverage}%25-darkgreen`}
           alt="Test Coverage Badge"
         />
       )}

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -7,6 +7,6 @@ import GetCoverageJSON from "../apps/docsite/src/components/GetCoverageJSON.tsx"
 
 | OS | Link | Status |
 |----|------|--------|
-| Code coverage for Windows | https://proud-island-067885010.4.azurestaticapps.net/windows-latest/index.html | <GetCoverageJSON OS="Windows"/> |
-| Code coverage for Ubuntu | https://proud-island-067885010.4.azurestaticapps.net/ubuntu-latest/index.html | <GetCoverageJSON OS="Ubuntu"/>  |
-| Code coverage for MacOS | https://proud-island-067885010.4.azurestaticapps.net/macos-latest/index.html | <GetCoverageJSON OS="MacOS"/> |
+| Code coverage for Windows | [Code Coverage Report](https://proud-island-067885010.4.azurestaticapps.net/windows-latest/index.html) | <GetCoverageJSON OS="Windows"/> |
+| Code coverage for Ubuntu | [Code Coverage Report](https://proud-island-067885010.4.azurestaticapps.net/ubuntu-latest/index.html) | <GetCoverageJSON OS="Ubuntu"/>  |
+| Code coverage for MacOS | [Code Coverage Report](https://proud-island-067885010.4.azurestaticapps.net/macos-latest/index.html) | <GetCoverageJSON OS="MacOS"/> |

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -5,7 +5,7 @@ Go through it to analyze if your code is validated through test automations.
 
 import GetCoverageJSON from "../apps/docsite/src/components/GetCoverageJSON.tsx"
 
-| OS | Link | Status |
+| OS | Link to report | Status |
 |----|------|--------|
 | Code coverage for Windows | [Code Coverage Report](https://proud-island-067885010.4.azurestaticapps.net/windows-latest/index.html) | <GetCoverageJSON OS="Windows"/> |
 | Code coverage for Ubuntu | [Code Coverage Report](https://proud-island-067885010.4.azurestaticapps.net/ubuntu-latest/index.html) | <GetCoverageJSON OS="Ubuntu"/>  |

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -5,7 +5,7 @@ Go through it to analyze if your code is validated through test automations.
 
 import GetCoverageJSON from "../apps/docsite/src/components/GetCoverageJSON.tsx"
 
-| OS | Link to report | Status |
+| OS | Report | Status |
 |----|------|--------|
 | Code coverage for Windows | [Code Coverage Report](https://proud-island-067885010.4.azurestaticapps.net/windows-latest/index.html) | <GetCoverageJSON OS="Windows"/> |
 | Code coverage for Ubuntu | [Code Coverage Report](https://proud-island-067885010.4.azurestaticapps.net/ubuntu-latest/index.html) | <GetCoverageJSON OS="Ubuntu"/>  |


### PR DESCRIPTION
This PR fixes the strings used in Test Coverage report in docusuarus docsite. It also adds write permissions for Github Actions Bot to allow pushing of bundle size json in repo via automated workflow