### PR TITLE
Store Changelog split updates in separate branch 

### DIFF
--- a/.github/workflows/generateChangelogs.yml
+++ b/.github/workflows/generateChangelogs.yml
@@ -36,13 +36,13 @@ jobs:
         mkdir ./changelogSplits
         mv -f ./../../dist/* ./changelogSplits
 
-    - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v6
+    - name: Get current timestamp
+      id: timestamp
+      run: echo "::set-output name=timestamp::$(date +%Y%m%d%H%M%S)"
+    
+    - name: Commit changes to repo
+      uses: stefanzweifel/git-auto-commit-action@v5
       with:
-        commit-message: Updating changelogs
-        delete-branch: true
-        path: ./repo
-        branch: update-changelog
-        branch-suffix: short-commit-hash
-        title: Automated update of CHANGELOG.md
-        body: This PR adds updates to the docsite CHANGELOG
+        repository: repo
+        branch: changelog-${{ steps.timestamp.outputs.timestamp }}
+        create_branch: true

--- a/.github/workflows/generateChangelogs.yml
+++ b/.github/workflows/generateChangelogs.yml
@@ -38,7 +38,9 @@ jobs:
 
     - name: Get current timestamp
       id: timestamp
-      run: echo "::set-output name=timestamp::$(date +%Y%m%d%H%M%S)"
+      run: |
+        echo "::set-output name=timestamp::$(date +%Y%m%d%H%M%S)"
+        echo "::set-output name=displayTimestamp::$(date +%Y-%m-%d\ %H:%M:%S)"
     
     - name: Commit changes to repo
       uses: stefanzweifel/git-auto-commit-action@v5
@@ -46,3 +48,4 @@ jobs:
         repository: repo
         branch: changelog-${{ steps.timestamp.outputs.timestamp }}
         create_branch: true
+        commit_message: Changelog update on ${{ steps.timestamp.outputs.displayTimestamp }}


### PR DESCRIPTION
This PR modifies the generateChangelog workflow to push the changelog changes to a separate branch instead of automatically creating a PR. 