### PR TITLE
Add tool to run python code and return fluent declarative chart image…

### DIFF
--- a/apps/plotly_examples/mcp-server/package.json
+++ b/apps/plotly_examples/mcp-server/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.16.0",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "puppeteer": "^21.11.0"
   },
   "devDependencies": {
     "@types/express": "^5.0.3",


### PR DESCRIPTION
Tool name: execute-python-and-capture-chart

This tool takes python code as string as an argument from the fluent chart agent, runs that python code,
generates 3 json schemas from it and returns back 3 images to the agent back