### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/azure-static-web-apps-lively-moss-052e9b910.yml
+++ b/.github/workflows/azure-static-web-apps-lively-moss-052e9b910.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           submodules: true
           lfs: false
       - name: Build And Deploy
         id: builddeploy
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_LIVELY_MOSS_052E9B910 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Close Pull Request
         id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_LIVELY_MOSS_052E9B910 }}
           action: "close"

--- a/.github/workflows/bundlesize.yml
+++ b/.github/workflows/bundlesize.yml
@@ -19,14 +19,14 @@ jobs:
   run-monosize:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: ${{github.event.inputs.repo || 'microsoft/fluentui'}}
           ref: ${{github.event.inputs.branch || 'master'}}
           path: repo
           
       
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: '20.x'
           cache: yarn
@@ -45,7 +45,7 @@ jobs:
           cd ./../../../
           rm -rf ./repo
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: 'microsoft/fluentui-charting-contrib'
           ref: 'test-coverage-artifacts'
@@ -64,7 +64,7 @@ jobs:
           ls -a
 
       - name: Push bundle-size to branch
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
         with:
           repository: contrib-repo
           branch: test-coverage-artifacts

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Enable Git long paths
         run: git config --global core.longpaths true
         
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 18
           cache: yarn
@@ -38,7 +38,7 @@ jobs:
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:

--- a/.github/workflows/generateChangelogs.yml
+++ b/.github/workflows/generateChangelogs.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Setup NodeJS"
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: 18
     
     - name: "Checkout fluentui-charting-contrib"
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         path: "repo"
     
@@ -44,7 +44,7 @@ jobs:
     
     - name: Commit changes to repo
       id: auto-commit-action
-      uses: stefanzweifel/git-auto-commit-action@v5
+      uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
       with:
         repository: repo
         branch: changelog-${{ steps.timestamp.outputs.timestamp }}

--- a/.github/workflows/main_fluentchartseval.yml
+++ b/.github/workflows/main_fluentchartseval.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Enable Git long paths
         run: git config --global core.longpaths true
         
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: '22.x'
       
@@ -48,7 +48,7 @@ jobs:
           yarn build
       
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: node-app
           path: apps/plotly_examples/build
@@ -68,19 +68,19 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: node-app
       
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
         with:
           client-id: ${{ secrets.AZUREAPPSERVICE_CLIENTID_B92B0539D2FB4B13B3C2BF3836380051 }}
           tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_CD6B9D2724174DCDB4E21F2A3B84BA2C }}
           subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_A0C748A7FDB947D1892147A405E56AA6 }}
 
       - name: 'Deploy to Azure Web App'
-        uses: azure/webapps-deploy@v3
+        uses: azure/webapps-deploy@02a81bead70021f5284939794bcec79c271ab383 # v3.0.8
         id: deploy-to-webapp
         with:
           app-name: 'fluentchartseval'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,9 +35,9 @@ jobs:
         working-directory: docs
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
@@ -45,7 +45,7 @@ jobs:
           working-directory: '${{ github.workspace }}/docs'
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@b8130d9ab958b325bbde9786d62f2c97a9885a0e # v3.0.7
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
@@ -53,7 +53,7 @@ jobs:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@84bb4cd4b733d5c320c9c9cfbc354937524f4d64 # v1.0.10
         with:
           path: "docs/_site/"
 
@@ -67,4 +67,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@de14547edc9944350dc0481aa5b7afb08e75f254 # v2.0.5

--- a/.github/workflows/plotlyTestCoverage.yml
+++ b/.github/workflows/plotlyTestCoverage.yml
@@ -34,7 +34,7 @@ jobs:
               run: git config --global core.longpaths true
 
             - name: Checkout [react-charting]
-              uses: actions/checkout@v4
+              uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
               with:
                 repository: ${{ github.event.inputs.repo || 'microsoft/fluentui'}}
                 ref: ${{ github.event.inputs.branch || 'master'}}
@@ -54,7 +54,7 @@ jobs:
               run: ls ./repo1
 
             - name: Set up Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
                 node-version: '22.x'
 
@@ -81,19 +81,19 @@ jobs:
               id: pack-chart-v8
 
             - name: Upload chart-utilities.tgz as artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
                 name: chart-utilities-tgz
                 path: ./repo1/packages/charts/chart-utilities/chart-utilities.tgz
 
             - name: Upload react-charting.tgz as artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
                 name: react-charting-tgz
                 path: ./repo1/packages/charts/react-charting/react-charting.tgz
 
             - name: Checkout [main] of current repo
-              uses: actions/checkout@v4
+              uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
               with:
                 path: contrib_repo
 
@@ -137,13 +137,13 @@ jobs:
                 baseline_report: contrib_repo/apps/plotly_examples/reports/playwright-report-v8.json        
 
             - name: Upload Playwright HTML report as artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with: 
                 name: playwright-html-report
                 path: contrib_repo/apps/plotly_examples/playwright-report/
 
             - name: Upload Playwright JSON report as artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with: 
                 name: playwright-json-report
                 path: contrib_repo/apps/plotly_examples/playwright-report.json
@@ -162,7 +162,7 @@ jobs:
                 yarn monosize measure
 
             - name: Upload monosize JSON report as artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with: 
                 name: monosize-report
                 path: repo1/packages/charts/react-charting/dist/bundle-size/monosize.json
@@ -177,7 +177,7 @@ jobs:
 
             - name: Commit and push v8 scheduled report
               if: github.event_name == 'schedule'
-              uses: stefanzweifel/git-auto-commit-action@v5
+              uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
               with:
                 branch: ${{ steps.branch.outputs.branch }}
                 create_branch: true

--- a/.github/workflows/plotlyTestCoverage_v9.yml
+++ b/.github/workflows/plotlyTestCoverage_v9.yml
@@ -33,7 +33,7 @@ jobs:
               run: git config --global core.longpaths true
               
             - name: Checkout [react-charting]
-              uses: actions/checkout@v4
+              uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
               with:
                 repository: ${{ github.event.inputs.repo || 'microsoft/fluentui'}}
                 ref: ${{ github.event.inputs.branch || 'master'}}
@@ -53,7 +53,7 @@ jobs:
               run: ls ./repo1
 
             - name: Set up Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
                 node-version: '22.x'
 
@@ -80,19 +80,19 @@ jobs:
               id: pack-chart-v9
 
             - name: Upload chart-utilities.tgz as artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
                 name: chart-utilities-tgz
                 path: ./repo1/packages/charts/chart-utilities/chart-utilities.tgz
 
             - name: Upload react-charts.tgz as artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
                 name: react-charts-tgz
                 path: ./repo1/packages/charts/react-charts/library/react-charts.tgz
 
             - name: Checkout [main] of current repo
-              uses: actions/checkout@v4
+              uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
               with:
                 path: contrib_repo
 
@@ -136,13 +136,13 @@ jobs:
                 baseline_report: contrib_repo/apps/plotly_examples/reports/playwright-report-v9.json        
 
             - name: Upload Playwright HTML report as artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with: 
                 name: playwright-html-report
                 path: contrib_repo/apps/plotly_examples/playwright-report/
 
             - name: Upload Playwright JSON report as artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with: 
                 name: playwright-json-report
                 path: contrib_repo/apps/plotly_examples/playwright-report.json
@@ -165,7 +165,7 @@ jobs:
 
             - name: Commit and push v9 scheduled report
               if: github.event_name == 'schedule'
-              uses: stefanzweifel/git-auto-commit-action@v5
+              uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
               with:
                 branch: ${{ steps.branch.outputs.branch }}
                 create_branch: true

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -13,8 +13,8 @@ jobs:
     name: Test deployment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 18
           cache: yarn

--- a/.github/workflows/testCoverage.yml
+++ b/.github/workflows/testCoverage.yml
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout [master]
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Checkout [react-charting]
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: ${{ github.event.inputs.repo || 'microsoft/fluentui' }}
           ref: ${{ github.event.inputs.branch || 'master' }}
@@ -49,7 +49,7 @@ jobs:
         run: ls ./repo1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22.x'
 
@@ -96,20 +96,20 @@ jobs:
         run: |
           echo "COVERAGE_FILENAME=test_coverage_${{ matrix.os }}_$(date +'%Y-%m-%d_%H-%M-%S')" >> $GITHUB_ENV
       - name: Save coverage folder
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{matrix.os}}
           path: ./repo1/packages/charts/react-charting/coverage/${{matrix.os}}
 
       - name: Save coverage file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{env.COVERAGE_FILENAME}}_report
           path: ./repo1/packages/charts/react-charting/coverageReport.txt
 
       - name: Save coverage folder for a single test
         if: matrix.os == 'windows-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage_VBC
           path: ./repo1/packages/charts/react-charting/coverage/${{matrix.os}}_VerticalBarChart
@@ -137,33 +137,33 @@ jobs:
 
     steps:
       - name: Download all artifacts to publish together
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: "ubuntu-latest"
           path: "./coverage/ubuntu-latest"
         continue-on-error: true
 
       - name: Download all artifacts to publish together
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: "macos-latest"
           path: "./coverage/macos-latest"
         continue-on-error: true
 
       - name: Download all artifacts to publish together
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: "windows-latest"
           path: "./coverage/windows-latest"
 
       - name: Download all artifacts to publish together
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: "coverage_VBC"
           path: "./coverage/coverage_VBC"
 
       - name: Download all artifacts to publish together
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: test_coverage_*
           path: "./coverage/coverageFiles"
@@ -175,10 +175,10 @@ jobs:
         shell: bash
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: "./coverage"
 
@@ -186,7 +186,7 @@ jobs:
         run: ls -a
 
       - name: Checkout [test-coverage-artifacts]
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           path: repo
           ref: test-coverage-artifacts
@@ -234,7 +234,7 @@ jobs:
           ls
         continue-on-error: true
         
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
         with:
           repository: repo
           branch: test-coverage-artifacts

--- a/.github/workflows/testCoverageWebsiteDeployment.yml
+++ b/.github/workflows/testCoverageWebsiteDeployment.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           submodules: true
           lfs: false
       - name: Build And Deploy
         id: builddeploy
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_RED_SAND_077904510 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Close Pull Request
         id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_RED_SAND_077904510 }}
           action: "close"

--- a/.github/workflows/testCoverage_v9storybook.yml
+++ b/.github/workflows/testCoverage_v9storybook.yml
@@ -33,7 +33,7 @@ jobs:
               run: git config --global core.longpaths true
 
             - name: Checkout [react-charting]
-              uses: actions/checkout@v4
+              uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
               with:
                 repository: ${{ github.event.inputs.repo || 'microsoft/fluentui'}}
                 ref: ${{ github.event.inputs.branch || 'master'}}
@@ -53,7 +53,7 @@ jobs:
               run: ls ./repo1
 
             - name: Set up Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
                 node-version: '22.x'
 
@@ -63,7 +63,7 @@ jobs:
                 yarn
 
             - name: Checkout [main] of current repo
-              uses: actions/checkout@v4
+              uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
               with:
                 path: contrib_repo
 
@@ -94,13 +94,13 @@ jobs:
                 baseline_report: contrib_repo/apps/plotly_examples/reports/playwright-report-v9Storybook.json        
 
             - name: Upload Playwright HTML report as artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with: 
                 name: playwright-html-report
                 path: contrib_repo/apps/plotly_examples/playwright-report/
 
             - name: Upload Playwright JSON report as artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with: 
                 name: playwright-json-report
                 path: contrib_repo/apps/plotly_examples/playwright-report.json
@@ -123,7 +123,7 @@ jobs:
 
             - name: Commit and push v9 scheduled report
               if: github.event_name == 'schedule'
-              uses: stefanzweifel/git-auto-commit-action@v5
+              uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
               with:
                 branch: ${{ steps.branch.outputs.branch }}
                 create_branch: true

--- a/.github/workflows/update_v8_package.yml
+++ b/.github/workflows/update_v8_package.yml
@@ -17,13 +17,13 @@ jobs:
         run: git config --global core.longpaths true
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: main
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22.x'
 
@@ -102,7 +102,7 @@ jobs:
 
       - name: Commit changes to repo
         id: auto-commit-action
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
         if: steps.check_update.outputs.up_to_date == 'false'
         with:
           branch: ${{ steps.branch.outputs.branch }}

--- a/.github/workflows/update_v8_snapshots.yml
+++ b/.github/workflows/update_v8_snapshots.yml
@@ -22,10 +22,10 @@ jobs:
             - name: Enable Git long paths
               run: git config --global core.longpaths true
               
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
             - name: Set up Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
                 node-version: '22.x'
 
@@ -65,7 +65,7 @@ jobs:
             - name: Commit changes to repo
               if: github.event_name == 'workflow_dispatch' || steps.skip_check.outputs.skip_job != 'true'
               id: auto-commit-action
-              uses: stefanzweifel/git-auto-commit-action@v5
+              uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
               with:
                 branch: ${{ steps.branch.outputs.branch }}
                 create_branch: true

--- a/.github/workflows/update_v9_package.yml
+++ b/.github/workflows/update_v9_package.yml
@@ -17,13 +17,13 @@ jobs:
         run: git config --global core.longpaths true
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: main
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22.x'
 
@@ -97,7 +97,7 @@ jobs:
 
       - name: Commit changes to repo
         id: auto-commit-action
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
         if: steps.check_update.outputs.up_to_date == 'false'
         with:
           branch: ${{ steps.branch.outputs.branch }}

--- a/.github/workflows/update_v9_snapshots.yml
+++ b/.github/workflows/update_v9_snapshots.yml
@@ -22,10 +22,10 @@ jobs:
             - name: Enable Git long paths
               run: git config --global core.longpaths true
 
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
             - name: Set up Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
                 node-version: '22.x'
 
@@ -65,7 +65,7 @@ jobs:
             - name: Commit changes to repo
               if: github.event_name == 'workflow_dispatch' || steps.skip_check.outputs.skip_job != 'true'
               id: auto-commit-action
-              uses: stefanzweifel/git-auto-commit-action@v5
+              uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
               with:
                 branch: ${{ steps.branch.outputs.branch }}
                 create_branch: true

--- a/.github/workflows/update_v9_storybook_snapshots.yml
+++ b/.github/workflows/update_v9_storybook_snapshots.yml
@@ -21,7 +21,7 @@ jobs:
               run: git config --global core.longpaths true
 
             - name: Checkout [react-charting]
-              uses: actions/checkout@v4
+              uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
               with:
                 repository: ${{ github.event.inputs.repo || 'microsoft/fluentui'}}
                 ref: ${{ github.event.inputs.branch || 'master'}}
@@ -41,7 +41,7 @@ jobs:
               run: ls ./repo1
 
             - name: Set up Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
                 node-version: '22.x'
 
@@ -51,7 +51,7 @@ jobs:
                 yarn
 
             - name: Checkout [main] of current repo
-              uses: actions/checkout@v4
+              uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
               with:
                 path: contrib_repo
 
@@ -79,7 +79,7 @@ jobs:
             - name: Commit changes to repo
               if: github.event_name == 'workflow_dispatch' || steps.skip_check.outputs.skip_job != 'true'
               id: auto-commit-action
-              uses: stefanzweifel/git-auto-commit-action@v5
+              uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
               with:
                 branch: ${{ steps.branch.outputs.branch }}
                 repository: contrib_repo


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
